### PR TITLE
Use valid category value in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=Max Chan <max@maxchan.info>
 maintainer=Max Chan <max@maxchan.info>
 sentence=Driver for Analog Devices AD5241/2 and AD5280/2 digital potentiometers.
 paragraph=The Analog Devices AD5241/2 series and their higher voltage siblings AD5280/2 series are one family of percision 8-bit digital potentiometers.
-category=Input/Output
+category=Signal Input/Output
 url=https://en.maxchan.info/arduino#ad5241
 architectures=*


### PR DESCRIPTION
Using any category value not on the[ valid category list](https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format) in the library specification causes a warning on every compile(whether or not this library is included in the program) in Arduino IDE 1.6.6 or greater:

```
WARNING: Category 'Input/Output' in library ArduMax AD5241 Driver is not valid. Setting to 'Uncategorized'
```

I chose the category that seemed closest to the previous value but am happy to change it to any other valid category value and squash to a single commit.
